### PR TITLE
QS tile titles visibility [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4798,6 +4798,12 @@ public static final String PHONE_BLACKLIST_REGEX_ENABLED = "phone_blacklist_rege
         public static final String TRANSPARENT_VOLUME_DIALOG = "transparent_volume_dialog";
 
         /**
+         * Whether to display qs tile titles in the qs panel
+         * @hide
+         */
+        public static final String QS_TILE_TITLE_VISIBILITY = "qs_tile_title_visibility";
+
+        /**
          * Volume dialog stroke
          * 0 = disabled
          * 1 = use accent color (default)

--- a/packages/SystemUI/res/values/rr_dimens.xml
+++ b/packages/SystemUI/res/values/rr_dimens.xml
@@ -58,4 +58,7 @@
     <dimen name="pie_tab_title_height">24dp</dimen>
     <dimen name="pie_panel_padding">20dp</dimen>
 
+    <!-- Qs visibility -->
+    <dimen name="qs_tile_height_wo_label">48dp</dimen>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/QSTileView.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSTileView.java
@@ -19,6 +19,7 @@ package com.android.systemui.qs;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.provider.Settings;
 import android.util.MathUtils;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -93,10 +94,22 @@ public class QSTileView extends QSTileBaseView {
     @Override
     protected void handleStateChanged(QSTile.State state) {
         super.handleStateChanged(state);
+        textVisibility();
         if (!Objects.equal(mLabel.getText(), state.label)) {
             mLabel.setText(state.label);
         }
         mLabel.setEnabled(!state.disabledByPolicy);
         mPadLock.setVisibility(state.disabledByPolicy ? View.VISIBLE : View.GONE);
+    }
+
+    public void textVisibility() {
+        if (Settings.System.getInt(mContext.getContentResolver(),
+             Settings.System.QS_TILE_TITLE_VISIBILITY, 1) == 1) {
+           mLabel.setVisibility(View.VISIBLE);
+           requestLayout();
+        } else {
+           mLabel.setVisibility(View.GONE);
+           requestLayout();
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/qs/TileLayout.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/TileLayout.java
@@ -145,6 +145,14 @@ public class TileLayout extends ViewGroup implements QSTileLayout {
         int columns = Settings.System.getIntForUser(
                 mContext.getContentResolver(), Settings.System.QS_LAYOUT_COLUMNS, mDefaultColumns,
                 UserHandle.USER_CURRENT);
+
+        if (Settings.System.getInt(mContext.getContentResolver(),
+             Settings.System.QS_TILE_TITLE_VISIBILITY, 1) == 1) {
+            mCellHeight = mContext.getResources().getDimensionPixelSize(R.dimen.qs_tile_height);
+        } else {
+            mCellHeight = mContext.getResources().getDimensionPixelSize(R.dimen.qs_tile_height_wo_label);
+        }
+
         if (mColumns != columns) {
             mColumns = columns;
             requestLayout();


### PR DESCRIPTION
Pretty simple mod to remove tile titles if and when the titles become
something that you don't want. A good case for this is if you set 7 or more
columns across, the titles move down to 2 lines and is just looks awful IMO

Before - https://i.imgur.com/G3ICaqb.png
After - https://i.imgur.com/Hb0J1XW.png

PS2 - Thanks to @maxwen for the know how to adjust the gap when titles
are removed

Change-Id: I10c534c5383397ce777f3ab0bdc0fa82fad6a7e1
Signed-off-by: Varun Date <date.varun123@gmail.com>